### PR TITLE
add filters for recipes on homepage

### DIFF
--- a/WeeklyBite - back/src/main/java/com/backend/weeklybite/controller/RecipeController.java
+++ b/WeeklyBite - back/src/main/java/com/backend/weeklybite/controller/RecipeController.java
@@ -1,19 +1,28 @@
 package com.backend.weeklybite.controller;
 
 import com.backend.weeklybite.domain.PagedResponse;
+import com.backend.weeklybite.domain.Recipe;
+import com.backend.weeklybite.domain.UserAccount;
 import com.backend.weeklybite.dto.recipe.GetRecipeDTO;
+import com.backend.weeklybite.dto.recipe.RecipeFilterDTO;
+import com.backend.weeklybite.exception.UserNotFoundException;
+import com.backend.weeklybite.service.AuthService;
 import com.backend.weeklybite.service.FileStorageService;
 import com.backend.weeklybite.service.RecipeService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @CrossOrigin(origins="*")
@@ -22,6 +31,9 @@ public class RecipeController {
 
     @Autowired
     private RecipeService recipeService;
+
+    @Autowired
+    private AuthService authService;
 
     @Autowired
     private FileStorageService fileStorageService;
@@ -42,5 +54,42 @@ public class RecipeController {
         Page<GetRecipeDTO> recipes = recipeService.getAllRecipes(pageable);
         PagedResponse<GetRecipeDTO> pagedCategoriesDTO = new PagedResponse<>(recipes.getContent(), (int) Math.ceil((double) count / pageable.getPageSize()), count);
         return new ResponseEntity<>(pagedCategoriesDTO, HttpStatus.OK);
+    }
+
+    @GetMapping(path = "/filter", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Page<GetRecipeDTO>> filterServices(
+            @ModelAttribute RecipeFilterDTO filter,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        Sort sort = Sort.unsorted();
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Long currentUserId = -1L;
+        List<Long> blockedUserIds = null;
+
+        try {
+            UserAccount userAccount = authService.getAuthenticatedUserAccount();
+            currentUserId = userAccount.getId();
+        } catch (UsernameNotFoundException | UserNotFoundException e) {
+            // blockedUserIds is null
+        }
+
+        Page<Recipe> services = recipeService.filterRecipes(filter, pageable);
+
+        // Page<Service> services = serviceService.filterServices(filter, pageable);
+        Page<GetRecipeDTO> dtoPage = services.map(service -> {
+            GetRecipeDTO dto = modelMapper.map(service, GetRecipeDTO.class);
+            if (service.getPictures() != null && !service.getPictures().isEmpty()) {
+                List<String> urls = service.getPictures().stream()
+                        .map(fileStorageService::getFileUrl)
+                        .collect(Collectors.toList());
+                dto.setPictures(urls);
+            } else {
+                dto.setPictures(null);
+            }
+            return dto;
+        });
+
+        return ResponseEntity.ok(dtoPage);
     }
 }

--- a/WeeklyBite - back/src/main/java/com/backend/weeklybite/dto/recipe/RecipeFilterDTO.java
+++ b/WeeklyBite - back/src/main/java/com/backend/weeklybite/dto/recipe/RecipeFilterDTO.java
@@ -1,0 +1,23 @@
+package com.backend.weeklybite.dto.recipe;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RecipeFilterDTO {
+
+    private String name;
+    private String description;
+    private String searchQuery;
+    private Integer duration;
+    private String content;
+    private Integer numberOfPeople;
+    private String category;
+
+    private Boolean breakfast;
+    private Boolean lunch;
+    private Boolean dinner;
+    private Boolean dessert;
+    private Boolean snack;
+}

--- a/WeeklyBite - back/src/main/java/com/backend/weeklybite/repository/RecipeRepository.java
+++ b/WeeklyBite - back/src/main/java/com/backend/weeklybite/repository/RecipeRepository.java
@@ -4,12 +4,14 @@ import com.backend.weeklybite.domain.Recipe;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
-public interface RecipeRepository   extends JpaRepository<Recipe, Long> {
+public interface RecipeRepository   extends JpaRepository<Recipe, Long>, JpaSpecificationExecutor<Recipe> {
 
     @Query("SELECT r From Recipe r WHERE r.isDeleted = false")
     Page<Recipe> findAllLast(Pageable pageable);
 
     Page<Recipe> findAllByIsDeletedOrderByUpdatedAsc(Pageable pageable, boolean b);
+
 }

--- a/WeeklyBite - back/src/main/java/com/backend/weeklybite/service/RecipeService.java
+++ b/WeeklyBite - back/src/main/java/com/backend/weeklybite/service/RecipeService.java
@@ -2,13 +2,16 @@ package com.backend.weeklybite.service;
 
 import com.backend.weeklybite.domain.Recipe;
 import com.backend.weeklybite.dto.recipe.GetRecipeDTO;
+import com.backend.weeklybite.dto.recipe.RecipeFilterDTO;
 import com.backend.weeklybite.repository.RecipeRepository;
 import com.backend.weeklybite.service.interfaces.IRecipeService;
+import com.backend.weeklybite.specification.RecipeSpecification;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -71,6 +74,11 @@ public class RecipeService implements IRecipeService {
 
     public long getRecipeCount() {
         return allRecipes.count();
+    }
+
+    public Page<Recipe> filterRecipes(RecipeFilterDTO filter, Pageable pageable) {
+        Specification<Recipe> specification = new RecipeSpecification(filter);
+        return allRecipes.findAll(specification, pageable);
     }
 }
 

--- a/WeeklyBite - back/src/main/java/com/backend/weeklybite/specification/RecipeSpecification.java
+++ b/WeeklyBite - back/src/main/java/com/backend/weeklybite/specification/RecipeSpecification.java
@@ -1,0 +1,87 @@
+package com.backend.weeklybite.specification;
+
+import com.backend.weeklybite.domain.Recipe;
+import com.backend.weeklybite.domain.enums.RecipeCategory;
+import com.backend.weeklybite.dto.recipe.RecipeFilterDTO;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecipeSpecification implements Specification<Recipe> {
+
+    private final RecipeFilterDTO dto;
+
+    public RecipeSpecification(RecipeFilterDTO dto) {
+        this.dto = dto;
+    }
+
+    @Override
+    public Predicate toPredicate(Root<Recipe> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (dto.getName() != null && !dto.getName().isBlank()) {
+            predicates.add(cb.like(cb.lower(root.get("name")), "%" + dto.getName().toLowerCase() + "%"));
+        }
+
+        if (dto.getDescription() != null && !dto.getDescription().isBlank()) {
+            predicates.add(cb.like(cb.lower(root.get("description")), "%" + dto.getDescription().toLowerCase() + "%"));
+        }
+
+        if (dto.getContent() != null && !dto.getContent().isBlank()) {
+            predicates.add(cb.like(cb.lower(root.get("content")), "%" + dto.getContent().toLowerCase() + "%"));
+        }
+
+        if (dto.getSearchQuery() != null && !dto.getSearchQuery().isBlank()) {
+            String search = "%" + dto.getSearchQuery().toLowerCase() + "%";
+            predicates.add(cb.or(
+                    cb.like(cb.lower(root.get("name")), search),
+                    cb.like(cb.lower(root.get("description")), search)
+            ));
+        }
+
+        if (dto.getNumberOfPeople() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("numberOfPeople"), dto.getNumberOfPeople()));
+        }
+
+        if (dto.getDuration() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("duration"), dto.getDuration()));
+        }
+
+        // Exclude deleted services
+        predicates.add(cb.isFalse(root.get("isDeleted")));
+
+        if (Boolean.TRUE.equals(dto.getBreakfast()) ||
+                Boolean.TRUE.equals(dto.getLunch()) ||
+                Boolean.TRUE.equals(dto.getDinner()) ||
+                Boolean.TRUE.equals(dto.getDessert()) ||
+                Boolean.TRUE.equals(dto.getSnack())) {
+
+            List<Predicate> categoryPredicates = new ArrayList<>();
+
+            if (Boolean.TRUE.equals(dto.getBreakfast())) {
+                categoryPredicates.add(cb.equal(root.get("category"), RecipeCategory.BREAKFAST));
+            }
+            if (Boolean.TRUE.equals(dto.getLunch())) {
+                categoryPredicates.add(cb.equal(root.get("category"), RecipeCategory.LUNCH));
+            }
+            if (Boolean.TRUE.equals(dto.getDinner())) {
+                categoryPredicates.add(cb.equal(root.get("category"), RecipeCategory.DINNER));
+            }
+            if (Boolean.TRUE.equals(dto.getDessert())) {
+                categoryPredicates.add(cb.equal(root.get("category"), RecipeCategory.DESSERT));
+            }
+            if (Boolean.TRUE.equals(dto.getSnack())) {
+                categoryPredicates.add(cb.equal(root.get("category"), RecipeCategory.SNACK));
+            }
+
+            predicates.add(cb.or(categoryPredicates.toArray(new Predicate[0])));
+        }
+
+        return cb.and(predicates.toArray(new Predicate[0]));
+    }
+}

--- a/WeeklyBite - back/src/main/resources/data.sql
+++ b/WeeklyBite - back/src/main/resources/data.sql
@@ -33,7 +33,9 @@ INSERT INTO ingredient (id, name, quantity, unit) VALUES
 INSERT INTO recipe (id, created, updated, name, content, description, duration, number_of_people, category, is_deleted, admin_id)
 VALUES
     (1, CURRENT_DATE, CURRENT_DATE, 'Pita sa sirom', 'Domaća pita sa sirom i jajima', '', 60, 4, 'BREAKFAST', FALSE, 1),
-    (2, CURRENT_DATE, CURRENT_DATE, 'Kolač sa jagodama', 'Slatki desert sa jagodama i šlagom', '', 90, 6, 'DESSERT', FALSE, 2);
+    (2, CURRENT_DATE, CURRENT_DATE, 'Kolač sa jagodama', 'Slatki desert sa jagodama i šlagom', '', 90, 6, 'DESSERT', FALSE, 2),
+    (3, CURRENT_DATE, CURRENT_DATE, 'Kolač sa sljivama', 'Slatki desert sa sljivama i šlagom', '', 120, 4, 'DESSERT', FALSE, 2),
+    (4, CURRENT_DATE, CURRENT_DATE, 'Kolač sa makom', 'Slatki desert sa makom i šlagom', '', 130, 3, 'DESSERT', FALSE, 2);
 
 -- Recept 1: Pita sa sirom
 INSERT INTO recipe_ingredient (recipe_id, ingredient_id) VALUES
@@ -51,7 +53,9 @@ INSERT INTO recipe_ingredient (recipe_id, ingredient_id) VALUES
 INSERT INTO recipe_pictures (recipe_id, picture_path) VALUES
     (1, 'pita.png'),
     (1, 'pita2.jpg'),
-    (2, 'kolac.jpg');
+    (2, 'kolac.jpg'),
+    (3, 'kolac.jpg'),
+    (4, 'kolac.jpg');
 
 
 SELECT setval('user_account_id_seq', (SELECT MAX(id) FROM user_account));


### PR DESCRIPTION
This PR implements a new backend feature that enables dynamic filtering of recipes on the homepage. This functionality provides a more tailored browsing experience for users.

---

### **Key Changes**

* **Dynamic Filtering Logic**: Implemented new filtering logic within the `RecipeService` to allow recipes to be filtered based on various criteria. The `RecipeController` now exposes this functionality through an updated endpoint.
* **New Filter DTO**: A new `RecipeFilterDTO` has been added to encapsulate filter parameters, ensuring clean and type-safe data transfer from the frontend.
* **Data Access Layer Updates**: The `RecipeRepository` and `data.sql` have been updated to support the new filtering queries and to ensure the database contains a diverse dataset for testing the new feature.
* **JPA Specification Pattern**: Utilized the JPA Specification pattern to build reusable and modular filtering logic.

These changes provide a robust foundation for the recipe filtering feature, allowing the frontend to offer a more personalized and efficient way for users to discover recipes.